### PR TITLE
add mac suffix to device name to prevent name conflicts

### DIFF
--- a/esphome/openshrooly.yaml
+++ b/esphome/openshrooly.yaml
@@ -1,5 +1,6 @@
 esphome:
   name: openshrooly
+  name_add_mac_suffix: true
   friendly_name: OpenShrooly
   project:
     name: grahamsz.openshrooly


### PR DESCRIPTION
With more than one unit, there's a naming conflict when adding to Home Assistant. I _think_ this might be the minimal change required to solve that.