### PR TITLE
Improve SoftAP recovery

### DIFF
--- a/esphome/components/globals.yaml
+++ b/esphome/components/globals.yaml
@@ -120,6 +120,22 @@ globals:
     type: unsigned long
     initial_value: '0'
 
+  # Wi-Fi/AP recovery state
+  - id: ap_restart_in_progress
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
+  - id: ap_last_restart_ms
+    type: unsigned long
+    restore_value: no
+    initial_value: '0'
+
+  - id: ap_status_text
+    type: std::string
+    restore_value: no
+    initial_value: '""'
+
   # UI globals
   - id: current_ui_page
     type: int

--- a/esphome/components/webserver.yaml
+++ b/esphome/components/webserver.yaml
@@ -1,4 +1,5 @@
 web_server:
+  id: http_server
   port: 80
   version: 3
   include_internal: true
@@ -31,4 +32,3 @@ web_server:
     - id: grp_hidden
       name: "Internal controls (should be hidden)"
       sorting_weight: 1000
-

--- a/esphome/lvgl_screens/00_main_screen.yaml
+++ b/esphome/lvgl_screens/00_main_screen.yaml
@@ -146,6 +146,14 @@
         y: 30
         text_font: font1
 
+    - label:
+        id: main_status_message
+        text: ""
+        align: BOTTOM_LEFT
+        x: 5
+        y: -5
+        text_font: font1
+
     # Button Bar - Settings button aligned with button 4 position
     # Single button on the right (20px tall, at bottom)
     - obj:

--- a/esphome/openshrooly.yaml
+++ b/esphome/openshrooly.yaml
@@ -43,7 +43,10 @@ esphome:
 
       # Restart WiFi AP after 5 seconds to ensure DHCP server is running
       - delay: 5s
-      - script.execute: wifi_ap_restart
+      - script.execute: wifi_ap_bounce
+      - script.wait: wifi_ap_bounce
+      - delay: 4s
+      - script.execute: wifi_ap_boot_verify
 
       # Wait until humidity is valid
       - wait_until:
@@ -86,7 +89,11 @@ wifi:
 
   on_connect:
     then:
-      - component.update: my_display   
+      - component.update: my_display
+
+  on_disconnect:
+    then:
+      - script.execute: wifi_ap_bounce
 
 captive_portal:
 
@@ -119,6 +126,53 @@ interval:
   - interval: 30s # Every 30 seconds, run the water level calculator
     then:
       - script.execute: water_level_calculator          
+
+  # Watchdog: nudge SoftAP/DHCP if the STA link stays down
+  - interval: 45s
+    then:
+      - lambda: |-
+          const uint32_t now = millis();
+
+          if (WiFi.isConnected()) {
+            return;
+          }
+
+          if (id(ap_restart_in_progress)) {
+            ESP_LOGD("wifi", "AP restart in progress; watchdog skipping.");
+            return;
+          }
+
+          IPAddress ap_ip = WiFi.softAPIP();
+          const uint32_t elapsed = now - id(ap_last_restart_ms);
+          const bool ip_expected = ap_ip.isSet() && ap_ip[0] == 192 && ap_ip[1] == 168 && ap_ip[2] == 4 && ap_ip[3] == 1;
+
+          if (ip_expected) {
+            return;
+          }
+
+          if (elapsed < 30000) {
+            ESP_LOGI(
+              "wifi",
+              "SoftAP IP %u.%u.%u.%u seen %ums after last restart; waiting before retry.",
+              static_cast<unsigned int>(ap_ip[0]),
+              static_cast<unsigned int>(ap_ip[1]),
+              static_cast<unsigned int>(ap_ip[2]),
+              static_cast<unsigned int>(ap_ip[3]),
+              static_cast<unsigned int>(elapsed)
+            );
+            return;
+          }
+
+          ESP_LOGW(
+            "wifi",
+            "SoftAP IP unhealthy (%u.%u.%u.%u); re-running restart helper.",
+            static_cast<unsigned int>(ap_ip[0]),
+            static_cast<unsigned int>(ap_ip[1]),
+            static_cast<unsigned int>(ap_ip[2]),
+            static_cast<unsigned int>(ap_ip[3])
+          );
+
+          id(wifi_ap_bounce).execute();
 
   # Update LVGL labels every 10 seconds
   - interval: 10s
@@ -177,20 +231,28 @@ interval:
       - lvgl.label.update:
           id: main_wifi_value
           text: !lambda |-
+            if (id(ap_restart_in_progress)) {
+              return std::string("Restarting AP...");
+            }
+
             if (WiFi.isConnected()) {
               return std::string("Connected");
-            } else {
-              return std::string("AP Mode");
             }
+
+            return std::string("AP Mode");
 
       - lvgl.label.update:
           id: main_ip_value
           text: !lambda |-
+            if (id(ap_restart_in_progress)) {
+              return std::string("--.--.--.--");
+            }
+
             if (WiFi.isConnected()) {
               return WiFi.localIP().toString().c_str();
-            } else {
-              return std::string("192.168.4.1");
             }
+
+            return std::string("192.168.4.1");
 
       - lvgl.label.update:
           id: main_time_label
@@ -213,6 +275,11 @@ interval:
             sprintf(str, "%dh %dm", hours, minutes);
             return std::string(str);
 
+      - lvgl.label.update:
+          id: main_status_message
+          text: !lambda |-
+            return id(ap_status_text).c_str();
+
       # Force display update
       - component.update: my_display
 
@@ -234,5 +301,3 @@ script: !include_dir_merge_list scripts/
 <<: !include components/buttons.yaml
 <<: !include components/lvgl_config.yaml
 <<: !include components/webserver.yaml
-
-

--- a/esphome/scripts/wifi_ap_boot_verify.yaml
+++ b/esphome/scripts/wifi_ap_boot_verify.yaml
@@ -1,0 +1,33 @@
+- id: wifi_ap_boot_verify
+  mode: single
+  then:
+    - if:
+        condition:
+          lambda: |-
+            IPAddress ap_ip = WiFi.softAPIP();
+            return ap_ip.isSet() && ap_ip[0] == 192 && ap_ip[1] == 168 && ap_ip[2] == 4 && ap_ip[3] == 1;
+        then:
+          - lambda: |-
+              IPAddress ap_ip = WiFi.softAPIP();
+              ESP_LOGI("wifi", "SoftAP IP verified after boot: %s", ap_ip.toString().c_str());
+              id(ap_status_text) = "AP ready";
+              id(ap_restart_in_progress) = false;
+          - component.update: my_display
+        else:
+          - lambda: |-
+              IPAddress ap_ip = WiFi.softAPIP();
+              ESP_LOGW("wifi", "SoftAP IP invalid after boot (%s); restarting DHCP.", ap_ip.toString().c_str());
+              id(ap_restart_in_progress) = true;
+              id(ap_last_restart_ms) = millis();
+              id(ap_status_text) = "Restarting AP...";
+          - component.update: my_display
+          - script.execute: wifi_ap_restart
+          - script.wait: wifi_ap_restart
+          - lambda: |-
+              IPAddress ap_ip = WiFi.softAPIP();
+              id(http_server).start_server();
+              id(ap_restart_in_progress) = false;
+              id(ap_last_restart_ms) = millis();
+              id(ap_status_text) = "AP DHCP restarted";
+              ESP_LOGI("wifi", "AP DHCP restarted; SoftAP IP now %s", ap_ip.toString().c_str());
+          - component.update: my_display

--- a/esphome/scripts/wifi_ap_bounce.yaml
+++ b/esphome/scripts/wifi_ap_bounce.yaml
@@ -1,0 +1,28 @@
+- id: wifi_ap_bounce
+  mode: single
+  then:
+    - lambda: |-
+        id(ap_restart_in_progress) = true;
+        id(ap_last_restart_ms) = millis();
+        id(ap_status_text) = "Restarting AP...";
+        ESP_LOGI("wifi", "Starting SoftAP bounce sequence...");
+
+    - component.update: my_display
+
+    - lambda: |-
+        ESP_LOGD("wifi", "Stopping HTTP server before SoftAP bounce");
+        id(http_server).stop_server();
+    - delay: 1s
+    - delay: !lambda 'return random(2000, 4000);'
+
+    - script.execute: wifi_ap_restart
+    - script.wait: wifi_ap_restart
+
+    - lambda: |-
+        ESP_LOGD("wifi", "Restarting HTTP server after SoftAP bounce");
+        id(http_server).start_server();
+    - lambda: |-
+        ESP_LOGI("wifi", "SoftAP bounce complete");
+        id(ap_restart_in_progress) = false;
+        id(ap_status_text) = "AP ready";
+    - component.update: my_display


### PR DESCRIPTION
## Summary
- bounce SoftAP and HTTP server when the STA link drops or the watchdog flags a bad IP
- verify SoftAP IP after boot and retry DHCP while surfacing status on the e-ink UI

Fixes #11.
Fixes #7.

## Testing
- python3 -m esphome config esphome/openshrooly.yaml
