### PR TITLE
Centralize coprocessor I2C access

### DIFF
--- a/esphome/components/buttons.yaml
+++ b/esphome/components/buttons.yaml
@@ -11,14 +11,6 @@ button:
     name: "Restart OpenShrooly"
     entity_category: diagnostic
 
-# I2C configuration (Bus A - for capacitive touch inputs)
-i2c:
-  - id: bus_a
-    sda: GPIO3
-    scl: GPIO4
-    scan: true
-    frequency: 100kHz
-
 # Touch Capacitive Sensors (AT42QT1010 chips)
 esp32_touch:
   setup_mode: false

--- a/esphome/components/calibration.yaml
+++ b/esphome/components/calibration.yaml
@@ -30,19 +30,15 @@ button:
             id(calibration_step) = 1;
           } else if (id(calibration_step) == 1) {
             // Read all 4 sensors in dry state
-            auto device = new i2c::I2CDevice();
-            device->set_i2c_bus(id(bus_a));
-            device->set_i2c_address(0x6C);
-
-            uint8_t data[4];
             uint8_t regs[] = {0x03, 0x07, 0x0B, 0x0F};
             uint32_t dry_values[4];
             bool success = true;
 
             for (int i = 0; i < 4; i++) {
-              if (!device->read_register(regs[i], data, 4)) {
-                dry_values[i] = (uint32_t)data[0] | ((uint32_t)data[1] << 8) |
-                               ((uint32_t)data[2] << 16) | ((uint32_t)data[3] << 24);
+              id(copro_bus).execute(0x6C, regs[i], 0, 0, 4);
+
+              if (!id(copro_last_error)) {
+                dry_values[i] = id(copro_last_read_u32);
               } else {
                 success = false;
                 break;
@@ -64,7 +60,6 @@ button:
               ESP_LOGE("calibration", "Failed to read sensors!");
             }
 
-            delete device;
           }
 
   # Cancel calibration button - cancels ongoing calibration process

--- a/esphome/components/globals.yaml
+++ b/esphome/components/globals.yaml
@@ -106,6 +106,16 @@ globals:
     restore_value: no
     initial_value: '0'
 
+  - id: copro_last_error
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
+  - id: copro_last_read_u32
+    type: uint32_t
+    restore_value: no
+    initial_value: '0'
+
   - id: fan_spinup_failure
     type: bool
     restore_value: no

--- a/esphome/components/outputs.yaml
+++ b/esphome/components/outputs.yaml
@@ -53,8 +53,8 @@ switch:
     optimistic: true
     turn_on_action:
       - lambda: |-
-          uint8_t data[2] = {0x00, 0x01};
-          bool err = id(bus_a).write(0x6C, data, 2);  // true = error
+          id(copro_bus).execute(0x6C, 0x00, 0x01, 2, 0);
+          bool err = id(copro_last_error);
           if (err) {
             ESP_LOGE("humidifier", "TURN ON: write to 0x6C failed (NACK)");
             id(i2c_failure_count) = id(i2c_failure_count) + 1;
@@ -68,8 +68,8 @@ switch:
           }
     turn_off_action:
       - lambda: |-
-          uint8_t data[2] = {0x00, 0x00};
-          bool err = id(bus_a).write(0x6C, data, 2);  // true = error
+          id(copro_bus).execute(0x6C, 0x00, 0x00, 2, 0);
+          bool err = id(copro_last_error);
           if (err) {
             ESP_LOGE("humidifier", "TURN OFF: write to 0x6C failed (NACK)");
             id(i2c_failure_count) = id(i2c_failure_count) + 1;

--- a/esphome/scripts/copro_bus.yaml
+++ b/esphome/scripts/copro_bus.yaml
@@ -1,0 +1,67 @@
+- id: copro_bus
+  mode: queued
+  parameters:
+    address: uint8_t
+    reg: uint8_t
+    write_value: uint32_t
+    write_length: uint8_t
+    read_length: uint8_t
+  then:
+    - lambda: |-
+        id(copro_last_error) = false;
+        id(copro_last_read_u32) = 0;
+
+        auto device = new i2c::I2CDevice();
+        device->set_i2c_bus(id(bus_a));
+        device->set_i2c_address(address);
+
+        bool error = false;
+
+        constexpr uint8_t kMaxWriteLength = 5;  // register + up to 4 bytes
+
+        if (write_length > 0) {
+          if (write_length > kMaxWriteLength) {
+            ESP_LOGE("copro", "Write length %u exceeds supported %u bytes", write_length, kMaxWriteLength);
+            error = true;
+          } else {
+            uint8_t buffer[kMaxWriteLength] = {0};
+            buffer[0] = reg;
+            for (uint8_t i = 1; i < write_length; ++i) {
+              buffer[i] = (write_value >> (8 * (i - 1))) & 0xFF;
+            }
+
+            auto ec = device->write(buffer, write_length);
+            if (ec != esphome::i2c::ErrorCode::OK) {
+              ESP_LOGW("copro", "Write to 0x%02X failed (err=%d)", address, static_cast<int>(ec));
+              error = true;
+            }
+          }
+        }
+
+        if (!error && read_length > 0) {
+          if (read_length > 4) {
+            ESP_LOGE("copro", "Read length %u exceeds supported 4 bytes", read_length);
+            error = true;
+            id(copro_last_read_u32) = 0;
+          } else {
+            uint8_t buffer[4] = {0};
+            auto ec = device->read_register(reg, buffer, read_length);
+            if (ec != esphome::i2c::ErrorCode::OK) {
+              ESP_LOGW("copro", "Read from 0x%02X failed (err=%d)", address, static_cast<int>(ec));
+              error = true;
+              id(copro_last_read_u32) = 0;
+            } else {
+              uint32_t value = 0;
+              for (uint8_t i = 0; i < read_length; ++i) {
+                value |= (uint32_t(buffer[i]) << (8 * i));
+              }
+              id(copro_last_read_u32) = value;
+            }
+          }
+        }
+
+        delete device;
+
+        if (error) {
+          id(copro_last_error) = true;
+        }

--- a/esphome/scripts/humidifier_pwm_control.yaml
+++ b/esphome/scripts/humidifier_pwm_control.yaml
@@ -19,16 +19,10 @@
             int on_time_ms = (int)(125.0f * speed_percent / 100.0f);
             int off_time_ms = 125 - on_time_ms;
 
-            // Turn on the humidifier fan via I2C
-            auto device = new i2c::I2CDevice();
-            device->set_i2c_bus(id(bus_a));
-            device->set_i2c_address(0x6C);  // Humidifier fan I2C address
-
-            uint8_t data[2];
-            data[0] = 0x00;  // Register
-            data[1] = 0x01;  // Turn on
-            device->write(data, 2);
-            delete device;
+            id(copro_bus).execute(0x6C, 0x00, 0x01, 2, 0);
+            if (id(copro_last_error)) {
+              ESP_LOGW("humidifier_pwm", "I2C ON pulse failed");
+            }
 
             // Keep on for the calculated duration
             id(humidifier_pwm_on_time) = on_time_ms;
@@ -39,16 +33,10 @@
             // Only turn off if we're doing PWM (not 100% duty)
             float speed_percent = id(humidifier_speed).state;
             if (speed_percent < 100.0f && id(humidifier_on_flag)) {
-              // Turn off the humidifier fan via I2C
-              auto device = new i2c::I2CDevice();
-              device->set_i2c_bus(id(bus_a));
-              device->set_i2c_address(0x6C);  // Humidifier fan I2C address
-
-              uint8_t data[2];
-              data[0] = 0x00;  // Register
-              data[1] = 0x00;  // Turn off
-              device->write(data, 2);
-              delete device;
+              id(copro_bus).execute(0x6C, 0x00, 0x00, 2, 0);
+              if (id(copro_last_error)) {
+                ESP_LOGW("humidifier_pwm", "I2C OFF pulse failed");
+              }
 
               // Calculate off time
               int off_time_ms = 125 - (int)(125.0f * speed_percent / 100.0f);
@@ -63,14 +51,9 @@
   # When loop exits (humidifier_on_flag = false), ensure fan is OFF
   - lambda: |-
       // Always turn off when stopping
-      auto device = new i2c::I2CDevice();
-      device->set_i2c_bus(id(bus_a));
-      device->set_i2c_address(0x6C);  // Humidifier fan I2C address
-
-      uint8_t data[2];
-      data[0] = 0x00;  // Register
-      data[1] = 0x00;  // Turn off
-      device->write(data, 2);
-      delete device;
+      id(copro_bus).execute(0x6C, 0x00, 0x00, 2, 0);
+      if (id(copro_last_error)) {
+        ESP_LOGW("humidifier_pwm", "Failed to ensure humidifier OFF on stop");
+      }
 
       ESP_LOGD("humidifier_pwm", "Humidifier PWM stopped - fan turned OFF");

--- a/esphome/scripts/humidifier_resync.yaml
+++ b/esphome/scripts/humidifier_resync.yaml
@@ -7,11 +7,10 @@
 interval: 60s  # Every minute, update the humidifier I2C register just in case it didn't register
 then:
   - lambda: |-
-      uint8_t data[2];
       if (id(humidifier_fan).state) {
         // Humidifier should be ON - send ON command
-        data[0] = 0x00; data[1] = 0x01;
-        bool err = id(bus_a).write(0x6C, data, 2);
+        id(copro_bus).execute(0x6C, 0x00, 0x01, 2, 0);
+        bool err = id(copro_last_error);
         if (err) {
           ESP_LOGW("humidifier_resync", "Failed to resync humidifier ON state");
         } else {
@@ -19,8 +18,8 @@ then:
         }
       } else {
         // Humidifier should be OFF - send OFF command
-        data[0] = 0x00; data[1] = 0x00;
-        bool err = id(bus_a).write(0x6C, data, 2);
+        id(copro_bus).execute(0x6C, 0x00, 0x00, 2, 0);
+        bool err = id(copro_last_error);
         if (err) {
           ESP_LOGW("humidifier_resync", "Failed to resync humidifier OFF state");
         } else {

--- a/esphome/scripts/humidity_control_manager.yaml
+++ b/esphome/scripts/humidity_control_manager.yaml
@@ -15,6 +15,11 @@
         float h = id(humidity).state;
         float t = id(target_humidity).state;
 
+        auto copro_write_humidifier = [&](uint8_t value) -> bool {
+          id(copro_bus).execute(0x6C, 0x00, value, 2, 0);
+          return !id(copro_last_error);
+        };
+
         // Don't control humidifier if humidity is 0 (sensor not initialized)
         if (h == 0.0f) {
           if (id(humidifier_on_flag)) {
@@ -23,16 +28,11 @@
             id(humidifier_pwm_control).stop();  // Stop PWM control script
 
             // Explicitly turn off the fan via I2C to ensure it's OFF
-            auto device = new i2c::I2CDevice();
-            device->set_i2c_bus(id(bus_a));
-            device->set_i2c_address(0x6C);
-            uint8_t data[2];
-            data[0] = 0x00;  // Register
-            data[1] = 0x00;  // Turn off
-            device->write(data, 2);
-            delete device;
-
-            ESP_LOGW("humidity", "Turning off humidifier - waiting for humidity sensor to initialize");
+            if (!copro_write_humidifier(0x00)) {
+              ESP_LOGW("humidity", "Failed to turn off humidifier while waiting for humidity sensor to initialize");
+            } else {
+              ESP_LOGW("humidity", "Turning off humidifier - waiting for humidity sensor to initialize");
+            }
           }
           // Show waiting status
           id(humidifier_fan_status).publish_state("Waiting to Settle");
@@ -76,14 +76,9 @@
           id(humidifier_pwm_control).stop();
 
           // Explicitly turn off the fan via I2C to ensure it's OFF
-          auto device = new i2c::I2CDevice();
-          device->set_i2c_bus(id(bus_a));
-          device->set_i2c_address(0x6C);
-          uint8_t data[2];
-          data[0] = 0x00;  // Register
-          data[1] = 0x00;  // Turn off
-          device->write(data, 2);
-          delete device;
+          if (!copro_write_humidifier(0x00)) {
+            ESP_LOGW("humidity", "Failed to send humidifier OFF command");
+          }
         }
 
         // Always publish status showing actual humidity

--- a/esphome/scripts/water_level_calculator.yaml
+++ b/esphome/scripts/water_level_calculator.yaml
@@ -13,28 +13,21 @@
       static bool first_reading = true;
 
       // Differential water level detection algorithm
-      auto device = new i2c::I2CDevice();
-      device->set_i2c_bus(id(bus_a));
-      device->set_i2c_address(0x6C);
-
       // I2C Memory Map addresses for sensors
       uint8_t regs[] = {0x03, 0x07, 0x0B, 0x0F};  // Empty, Low, Mid, High
       uint32_t sensor_vals[4] = {0};
-      uint8_t data[4];
 
       // 1. Read 32-bit values from each sensor
       for (int i = 0; i < 4; i++) {
-        if (device->read_register(regs[i], data, 4)) { // note true and false seem to be flipped!
+        id(copro_bus).execute(0x6C, regs[i], 0, 0, 4);
+
+        if (id(copro_last_error)) {
           ESP_LOGW("water", "Read failed at 0x%02X", regs[i]);
-          delete device;
           id(water_level_percent).publish_state(NAN);
           return;
         }
-        // Little-endian 32-bit value
-        sensor_vals[i] = (uint32_t)data[0]
-                       | ((uint32_t)data[1] << 8)
-                       | ((uint32_t)data[2] << 16)
-                       | ((uint32_t)data[3] << 24);
+
+        sensor_vals[i] = id(copro_last_read_u32);
       }
 
       // Determine water level - always use calibration values (defaults or user-set)
@@ -147,8 +140,6 @@
 
       // Log the final calculated percentage
       // ESP_LOGI("water", "Level: %.1f%% (avg: %.1f%%)", water_level, avg);
-
-      delete device;
 
       // Publish the result to the sensor
       id(water_level_percent).publish_state(avg);


### PR DESCRIPTION
## Summary
- collapse the duplicate I2C declarations into the primary GPIO36/35 bus
- add a queued copro_bus script plus globals to guard access and share readback data
- update humidifier and water-level routines to call the helper so concurrent ops serialize without NACKs
