### PR TITLE
Add deterministic device naming support

### DIFF
--- a/esphome/components/controls.yaml
+++ b/esphome/components/controls.yaml
@@ -358,6 +358,17 @@ text_sensor:
 
 button:
   - platform: template
+    id: device_name_next
+    name: "Next Device Name"
+    icon: mdi:shuffle-variant
+    entity_category: config
+    web_server:
+      sorting_group_id: grp_system
+      sorting_weight: 2
+    on_press:
+      - script.execute: device_name_generate
+
+  - platform: template
     name: "Beeper Test"
     icon: mdi:volume-high
     web_server:

--- a/esphome/components/globals.yaml
+++ b/esphome/components/globals.yaml
@@ -146,6 +146,12 @@ globals:
     restore_value: no
     initial_value: '""'
 
+  # Device identity helpers
+  - id: device_name_sequence
+    type: uint32_t
+    restore_value: yes
+    initial_value: '0'
+
   # UI globals
   - id: current_ui_page
     type: int
@@ -175,4 +181,3 @@ globals:
   - id: button_4_state
     type: bool
     initial_value: 'false'
-

--- a/esphome/components/texts.yaml
+++ b/esphome/components/texts.yaml
@@ -1,0 +1,24 @@
+# ========================================================================
+# TEXT COMPONENTS
+# Runtime-editable text fields stored in flash
+# ========================================================================
+
+text:
+  - platform: template
+    id: device_name
+    name: "Device Name"
+    icon: mdi:tag-text-outline
+    entity_category: config
+    optimistic: true
+    restore_value: true
+    mode: text
+    min_length: 0
+    max_length: 32
+    initial_value: ""
+    web_server:
+      sorting_group_id: grp_system
+      sorting_weight: 1
+    on_value:
+      then:
+        - lambda: |-
+            ESP_LOGI("device_name", "Device name updated to '%s'", x.c_str());

--- a/esphome/components/webserver.yaml
+++ b/esphome/components/webserver.yaml
@@ -7,6 +7,9 @@ web_server:
   js_include: ../assets/esphome.js
   app_html_include: ../webapp/out/index.html
   sorting_groups:
+    - id: grp_system
+      name: "System"
+      sorting_weight: 5
     - id: grp_air
       name: "Air Exchange"
       sorting_weight: 10

--- a/esphome/openshrooly.yaml
+++ b/esphome/openshrooly.yaml
@@ -51,6 +51,7 @@ esphome:
       - script.wait: wifi_ap_bounce
       - delay: 4s
       - script.execute: wifi_ap_boot_verify
+      - script.execute: ensure_device_name
 
       # Wait until humidity is valid
       - wait_until:
@@ -106,6 +107,7 @@ captive_portal:
 
 # Include text sensors early so scripts can reference them
 <<: !include components/text_sensors.yaml
+<<: !include components/texts.yaml
 
 # Scripts will be loaded after components to ensure all IDs are available
 

--- a/esphome/scripts/device_name_manager.yaml
+++ b/esphome/scripts/device_name_manager.yaml
@@ -1,0 +1,58 @@
+- id: device_name_generate
+  mode: restart
+  then:
+    - lambda: |-
+        auto generate_name = [](uint32_t sequence) -> std::string {
+          const char consonants[] = "bcdfghjklmnpqrstvwxyz";
+          const char vowels[] = "aeiou";
+          const size_t consonant_count = sizeof(consonants) - 1;
+          const size_t vowel_count = sizeof(vowels) - 1;
+
+          uint64_t mac = ESP.getEfuseMac();
+          uint64_t state = mac ^ (static_cast<uint64_t>(sequence) * 0x9E3779B97F4A7C15ULL) ^ 0xD1B54A32D192ED03ULL;
+          auto next_rand = [&state]() -> uint64_t {
+            state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+            return state;
+          };
+
+          uint8_t length = 3 + (next_rand() % 3);  // 3-5 letters
+          std::string name;
+          name.reserve(length);
+
+          for (uint8_t idx = 0; idx < length; idx++) {
+            const bool use_consonant = (idx % 2) == 0;
+            uint64_t value = next_rand();
+            if (use_consonant) {
+              char ch = consonants[value % consonant_count];
+              if (idx == 0 && ch >= 'a' && ch <= 'z') {
+                ch = static_cast<char>((ch - 'a') + 'A');
+              }
+              name.push_back(ch);
+            } else {
+              char ch = vowels[value % vowel_count];
+              name.push_back(ch);
+            }
+          }
+
+          return name;
+        };
+
+        uint32_t sequence = id(device_name_sequence);
+        std::string generated = generate_name(sequence);
+        if (generated.length() > 32) {
+          generated.resize(32);
+        }
+        id(device_name).publish_state(generated);
+        id(device_name_sequence) = sequence + 1;
+        ESP_LOGI("device_name", "Generated name #%u → %s", sequence, generated.c_str());
+
+- id: ensure_device_name
+  mode: queued
+  then:
+    - lambda: |-
+        if (!id(device_name).has_state() || id(device_name).state.empty()) {
+          ESP_LOGI("device_name", "Device name missing — generating default.");
+          id(device_name_generate).execute();
+        } else {
+          ESP_LOGD("device_name", "Existing device name retained: %s", id(device_name).state.c_str());
+        }


### PR DESCRIPTION
## Summary
- add ESPHome template text entity for device name with persisted storage
- generate deterministic pronounceable defaults seeded from device MAC
- expose script/button to cycle to the next suggested name on demand

## Testing
- not run (hardware not available)