### PR TITLE
Fix Timezone selector 

### DIFF
--- a/esphome/components/selects.yaml
+++ b/esphome/components/selects.yaml
@@ -6,7 +6,7 @@
 select:
   # Timezone selector with automatic DST handling
   - platform: template
-    id: timezone_select
+    id: timezone
     name: "Timezone"
     icon: mdi:map-clock-outline
     entity_category: config

--- a/webapp/app/page.tsx
+++ b/webapp/app/page.tsx
@@ -49,7 +49,7 @@ export default function Dashboard() {
       }
 
       try {
-        const tz = await api.getSelect('timezone_select')
+        const tz = await api.getSelect('timezone')
         if (tz?.state) setTimezone(tz.state)
       } catch (e) {
         // Ignore errors during initial fetch - EventSource will populate data
@@ -72,7 +72,7 @@ export default function Dashboard() {
         setLastUpdate(new Date())
 
         // Update timezone from events
-        if (event.id === 'select-timezone_select') {
+        if (event.id === 'select-timezone') {
           setTimezone(event.state)
         }
       }
@@ -120,7 +120,7 @@ export default function Dashboard() {
 
   const handleTimezoneChange = async (tz: string) => {
     setTimezone(tz)
-    await handleSelectChange('timezone_select', tz)
+    await handleSelectChange('timezone', tz)
   }
 
   const handleOtaUpload = async () => {


### PR DESCRIPTION
## Fix timezone change: 404 on timezone update request

### Problem
Changing the timezone from the web UI fails: the device responds 404 Not Found, so the timezone never updates.

### Root cause
The UI called POST /select/timezone_select/set?option=..., but the WebServer REST API routes selects by object_id (derived from name). For name: "Timezone", the actual REST id is timezone, so /select/timezone_select/... does not exist and returns 404.

### Fix

Update the web UI to use timezone for select GET/SET and event matching.
Rename the YAML id from timezone_select to timezone to match the REST id and avoid confusion.

### How to verify

```
HOST="openshrooly-d1dd11.local"

# Correct select endpoint exists (should be 200 + JSON)
curl -i "http://$HOST/select/timezone"

# Reproduce old bug (should be 404)
curl -i -X POST "http://$HOST/select/timezone_select/set" --data "" \
  --get --data-urlencode "option=Europe/Berlin"

# Verify fix: set timezone (should be 200)
curl -i -X POST "http://$HOST/select/timezone/set" --data "" \
  --get --data-urlencode "option=Europe/Berlin"

# Optional: if your setup uses /esphome prefix
curl -i -X POST "http://$HOST/esphome/select/timezone/set" --data "" \
  --get --data-urlencode "option=Europe/Berlin"
```
### Why timezone (not timezone_select)
Because the REST endpoint is keyed by object_id, which is already timezone (from the user-facing name “Timezone”). Using timezone fixes the 404 without changing the displayed label or server behavior.






